### PR TITLE
added PNG converter function, realised images set function via presenter

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="..\:/CodingWithFun/Kotlin/ImageConverter/app/src/main/res/layout/activity_main.xml" value="0.25416666666666665" />
         <entry key="..\:/CodingWithFun/Kotlin/ImageConverter/app/src/main/res/layout/fragment_convert.xml" value="0.25416666666666665" />
+        <entry key="..\:/CodingWithFun/Kotlin/ImageConverter/app/src/main/res/xml/filepaths.xml" value="0.1421875" />
       </map>
     </option>
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/example/imageconverter/ConvertFragment.kt
+++ b/app/src/main/java/com/example/imageconverter/ConvertFragment.kt
@@ -9,39 +9,61 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.isGone
 import kotlinx.android.synthetic.main.fragment_convert.*
 import moxy.MvpAppCompatFragment
 import moxy.ktx.moxyPresenter
 
-class ConvertFragment : MvpAppCompatFragment (), FragmentView {
-
+class ConvertFragment : MvpAppCompatFragment(), FragmentView {
     companion object {
         fun newInstance() = ConvertFragment()
-        var selectedFile : Uri? = null
-        var path : String? = null
+        var selectedFile: Uri? = null
+        var path: String? = null
     }
 
     private val presenter by moxyPresenter { ConvertFragmentPresenter() }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_convert, container,false)
+        return inflater.inflate(R.layout.fragment_convert, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        convertButton.setOnClickListener {}
+        convertButton.setOnClickListener {
+            val bitmap = (imageView.drawable as BitmapDrawable).bitmap
+            presenter.convertAndSaveNewImage(bitmap, path)
+            Toast.makeText(activity, "Wait a bit: converting new image...", Toast.LENGTH_SHORT).show()
+        }
 
-        selectButton.setOnClickListener {}
+        selectButton.setOnClickListener {
+            val intent = Intent()
+                .setType("*/*")
+                .setAction(Intent.ACTION_GET_CONTENT)
+            startActivityForResult(Intent.createChooser(intent, "Select a file"), 111)
+        }
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == 111 && resultCode == RESULT_OK) {
+            selectedFile = data?.data
+            path = context?.filesDir?.absolutePath
+            presenter.setPickedImage(selectedFile)
+        }
+    }
 
-    override fun setOriginalImage(selectedFile: Uri?) {}
+    override fun setOriginalImage(selectedFile: Uri?) {
+        imageView.setImageURI(selectedFile)
+        Toast.makeText(context, "New image was set from presenter", Toast.LENGTH_SHORT).show()
+    }
 
-    override fun setConvertedImage(newImage: Uri) {}
-
+    override fun setConvertedImage(newImage: Uri) {
+        imageView2.setImageURI(newImage)
+        Toast.makeText(context, "Image was converted to PNG and saved at $path", Toast.LENGTH_LONG)
+            .show()
+    }
 }

--- a/app/src/main/java/com/example/imageconverter/ConvertFragment.kt
+++ b/app/src/main/java/com/example/imageconverter/ConvertFragment.kt
@@ -9,12 +9,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.view.isGone
 import kotlinx.android.synthetic.main.fragment_convert.*
 import moxy.MvpAppCompatFragment
 import moxy.ktx.moxyPresenter
 
 class ConvertFragment : MvpAppCompatFragment(), FragmentView {
+
     companion object {
         fun newInstance() = ConvertFragment()
         var selectedFile: Uri? = null
@@ -22,6 +22,7 @@ class ConvertFragment : MvpAppCompatFragment(), FragmentView {
     }
 
     private val presenter by moxyPresenter { ConvertFragmentPresenter() }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -34,9 +35,14 @@ class ConvertFragment : MvpAppCompatFragment(), FragmentView {
         super.onViewCreated(view, savedInstanceState)
 
         convertButton.setOnClickListener {
-            val bitmap = (imageView.drawable as BitmapDrawable).bitmap
-            presenter.convertAndSaveNewImage(bitmap, path)
-            Toast.makeText(activity, "Wait a bit: converting new image...", Toast.LENGTH_SHORT).show()
+            try {
+                val bitmap = (imageView.drawable as BitmapDrawable).bitmap
+                presenter.convertAndSaveNewImage(bitmap, path)
+                Toast.makeText(activity, "Wait a bit: converting new image...", Toast.LENGTH_SHORT)
+                    .show()
+            } catch (e : NullPointerException) {
+                Toast.makeText(activity, "Wrong type of file", Toast.LENGTH_SHORT).show()
+            }
         }
 
         selectButton.setOnClickListener {

--- a/app/src/main/java/com/example/imageconverter/ConvertFragmentPresenter.kt
+++ b/app/src/main/java/com/example/imageconverter/ConvertFragmentPresenter.kt
@@ -1,13 +1,32 @@
 package com.example.imageconverter
 
-import moxy.MvpPresenter
 import android.graphics.Bitmap
 import android.net.Uri
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import moxy.MvpPresenter
 
 class ConvertFragmentPresenter : MvpPresenter<FragmentView>() {
 
     val disposable = CompositeDisposable()
+
+    fun setPickedImage(selectedFile: Uri?) {
+        viewState.setOriginalImage(selectedFile)
+    }
+
+    fun convertAndSaveNewImage(image: Bitmap, path: String?) {
+        disposable.addAll(
+            Converter.convertImage(image, path)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({ convertedImage ->
+                    viewState.setConvertedImage(Uri.parse(convertedImage.absolutePath))
+                }, { error ->
+                    println(error.message)
+                })
+        )
+    }
 
     override fun onDestroy() {
         disposable.dispose()

--- a/app/src/main/java/com/example/imageconverter/Converter.kt
+++ b/app/src/main/java/com/example/imageconverter/Converter.kt
@@ -1,16 +1,28 @@
 package com.example.imageconverter
 
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.net.Uri
-import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.core.SingleOnSubscribe
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
-import java.lang.Exception
 
 object Converter {
 
+    var counter = 1
+
+    fun convertImage(image: Bitmap, path: String?): Single<File> {
+        return Single.create(SingleOnSubscribe {
+            if (it.isDisposed) return@SingleOnSubscribe
+            val newImage = File(path, "NewImage${counter}.png")
+            val stream: OutputStream = FileOutputStream(newImage)
+            if (image.compress(Bitmap.CompressFormat.PNG, 100, stream)) {
+                it.onSuccess(newImage)
+                counter++
+            } else
+                it.onError(Exception("Conversion problem"))
+            stream.flush()
+            stream.close()
+        })
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="app_name">ImageConverter</string>
-    <string name="convert">Convert</string>
-    <string name="select">Select</string>
+    <string name="convert">Convert to PNG</string>
+    <string name="select">Select Image</string>
 </resources>


### PR DESCRIPTION
Собственно код для ДЗ реализован в коммите [с218801 ](https://github.com/Froyder/ImageConverter/pull/4/commits/c2188010e76ea389f18200990cceda4fc9701132).
Внутри ConvertFragment пользователь устанавливает картинку, которую нужно конвертировать. При нажатии на соответствующую кнопку вызывается метод convertAndSaveNewImage из ConvertFragmentPresenter. Тот, в свою очередь передает полученный Bitmap в объект Converter, где и происходит процесс конвертации (можно было сделать все внутри презентера, но я посчитал, что будет лучше прописать обработчика отдельно). Конвертер создает новый файл, сохраняет его в формате PNG, используя в качестве основы полученный битмап, и передает Single с результатом своих трудов в презентер. Тот, в свою очередь, командует вьюхе загрузить полученное изображение в соответствующий ImageView.
Вычисления идут в Schedulers.io(), а отслеживание результата - в AndroidSchedulers.mainThread(), так что процесс конвертации не грузит UI.
P.S. Во втором коммите прикрутил простенькую проверку на формат входящего файла (на случай, если пользователь пытается конвертировать что-то, что не является изображением).
P.P.S. На случай, если понадобится Initial commit, он лежит [здесь ](https://github.com/Froyder/ImageConverter/commit/479ae548774f6f61fe0532c812784346627b5f29).
  